### PR TITLE
use sub= in weapon specials instead od add=- and use [filter_special] instead of long list of special id

### DIFF
--- a/data/BMR_data/Archaic_abilities.cfg
+++ b/data/BMR_data/Archaic_abilities.cfg
@@ -563,7 +563,7 @@ A poisoned unit cannot be cured of its poison by a healer, and must seek the car
         [filter_opponent]
             [filter_weapon]
                 [not]
-                    special=magical
+                    special_id_active=magical
                 [/not]
             [/filter_weapon]
         [/filter_opponent]
@@ -574,7 +574,7 @@ A poisoned unit cannot be cured of its poison by a healer, and must seek the car
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
-                special=magical
+                special_id_active=magical
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]

--- a/data/BMR_data/Archaic_abilities.cfg
+++ b/data/BMR_data/Archaic_abilities.cfg
@@ -558,7 +558,7 @@ A poisoned unit cannot be cured of its poison by a healer, and must seek the car
         id=AE_arc_fog_enemy
         name= _"mind fog"
         description= _ "The opponent is enveloped in an opaque fog and cannot see very well, so their ability to hit (-10%), and especially cast a spell (-35%), is reduced."
-        add=-10
+        sub=10
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
@@ -570,7 +570,7 @@ A poisoned unit cannot be cured of its poison by a healer, and must seek the car
     [/chance_to_hit]
     [chance_to_hit]
         id=AE_arc_fog_enemy
-        add=-35
+        sub=35
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]

--- a/data/EFM_data/abilities/abilities.cfg
+++ b/data/EFM_data/abilities/abilities.cfg
@@ -7,7 +7,7 @@
         description= _ "Enemies next to a unit with this ability gain -20% resistances to everything except arcane."
         name_inactive= _ "decay"
         description_inactive= _ "Enemies next to a unit with this ability gain -20% resistances to everything except arcane."
-        add=-20
+        sub=20
         max_value=999
         affect_self=no
         affect_allies=no

--- a/data/ELE_data/abilities/transcendent.cfg
+++ b/data/ELE_data/abilities/transcendent.cfg
@@ -33,7 +33,7 @@ It also have terrible consecuences when next to Fallen Tamers."
     [/resistance]
 
     [resistance]
-        add=-20
+        sub=20
         max_value=999
         affect_self=yes
         affect_allies=yes
@@ -45,7 +45,7 @@ It also have terrible consecuences when next to Fallen Tamers."
     [/resistance]
 
     [resistance]
-        add=-10
+        sub=10
         max_value=999
         affect_self=yes
         affect_allies=yes

--- a/data/ELE_data/weapon_special/resistant.cfg
+++ b/data/ELE_data/weapon_special/resistant.cfg
@@ -9,6 +9,6 @@
         description_inactive= _ "When this attack is used offensively, this unit takes {VALUE} damage less on every strike."
         active_on=offense
         apply_to=opponent
-        add=-{VALUE}
+        sub={VALUE}
     [/damage]
 #enddef

--- a/data/EoMa_data/chancetohit.cfg
+++ b/data/EoMa_data/chancetohit.cfg
@@ -163,7 +163,11 @@
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
-                special_id_active=magical,AE_mag_magical_defensive,AE_mag_magical_offensive
+                [filter_special]
+                    active=yes
+                    tag_name=chance_to_hit
+                    value=70
+                [/filter_special]
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]
@@ -173,7 +177,11 @@
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
-                special_id_active=AE_mag_enchanted
+                [filter_special]
+                    active=yes
+                    tag_name=chance_to_hit
+                    value=60
+                [/filter_special]
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]
@@ -189,7 +197,11 @@
         active_on=offense
         [filter_opponent]
             [filter_weapon]
-                special_id=magical,AE_mag_magical_defensive,AE_mag_magical_offensive
+                [filter_special]
+                    active=yes
+                    tag_name=chance_to_hit
+                    value=70
+                [/filter_special]
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]
@@ -201,7 +213,11 @@
         active_on=offense
         [filter_opponent]
             [filter_weapon]
-                special_id=AE_mag_enchanted
+                [filter_special]
+                    active=yes
+                    tag_name=chance_to_hit
+                    value=60
+                [/filter_special]
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]

--- a/data/EoMa_data/chancetohit.cfg
+++ b/data/EoMa_data/chancetohit.cfg
@@ -159,21 +159,21 @@
         id=AE_mag_magic_counter
         name= _ "magic counter"
         description= _ "This attack reduces magical chance to hit of opponents by 20% (down to 50%). It also reduces enchanted chance to hit of opponents by 10% (down to 50% as well)."
-        add=-20
+        sub=20
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
-                special_id=magical,AE_mag_magical_defensive,AE_mag_magical_offensive
+                special_id_active=magical,AE_mag_magical_defensive,AE_mag_magical_offensive
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]
     [chance_to_hit]
         id=AE_mag_magic_counter2
-        add=-10
+        sub=10
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
-                special_id=AE_mag_enchanted
+                special_id_active=AE_mag_enchanted
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]
@@ -184,7 +184,7 @@
         id=AE_mag_magic_dodge
         name= _ "magic dodge"
         description= _ "When used offensively, this attack reduces magical chance to hit of opponents by 20% (down to 50%). It also reduces enchanted chance to hit of opponents by 10% (down to 50% as well)."
-        add=-20
+        sub=20
         apply_to=opponent
         active_on=offense
         [filter_opponent]
@@ -196,7 +196,7 @@
     [chance_to_hit]
         id=AE_mag_magic_dodge2
         name=""# wmllint: ignore
-        add=-10
+        sub=10
         apply_to=opponent
         active_on=offense
         [filter_opponent]

--- a/data/EoMa_data/runeaura.cfg
+++ b/data/EoMa_data/runeaura.cfg
@@ -196,7 +196,7 @@
     [/resistance]
     [resistance]
         id=AE_mag_runeauraactive_physical2
-        add=-30
+        sub=30
         max_value=70
         apply_to=blade,pierce,impact
         affect_self=no
@@ -252,7 +252,7 @@
     [/resistance]
     [resistance]
         id=AE_mag_runeauraactive_physical4
-        add=-30
+        sub=30
         max_value=70
         apply_to=blade,pierce,impact
         affect_self=no

--- a/data/FL_data/abilities.cfg
+++ b/data/FL_data/abilities.cfg
@@ -341,7 +341,7 @@ A unit cared for by this healer may heal up to 12 HP per turn, or stop poison fr
         id=AE_FGTNL_Dnajazd3
         name= _ ""
         active_on=offense
-        add=-10
+        sub=10
         apply_to=opponent
     [/chance_to_hit]
     [chance_to_hit]

--- a/data/Frozen_data/abilities/big_cold_protection.cfg
+++ b/data/Frozen_data/abilities/big_cold_protection.cfg
@@ -35,7 +35,7 @@
         [/affect_adjacent]
     [/resistance]
     [resistance]
-        add=-30
+        sub=30
         max_value=70
         affect_self=no
         affect_allies=no

--- a/data/Frozen_data/abilities/cold_protection.cfg
+++ b/data/Frozen_data/abilities/cold_protection.cfg
@@ -35,7 +35,7 @@
         [/affect_adjacent]
     [/resistance]
     [resistance]
-        add=-20
+        sub=20
         max_value=80
         apply_to=cold
         affect_self=no

--- a/data/Frozen_data/abilities/medium_cold_protection.cfg
+++ b/data/Frozen_data/abilities/medium_cold_protection.cfg
@@ -35,7 +35,7 @@
         [/affect_adjacent]
     [/resistance]
     [resistance]
-        add=-15
+        sub=15
         max_value=85
         apply_to=cold
         affect_self=no

--- a/data/Frozen_data/abilities/small_cold_protection.cfg
+++ b/data/Frozen_data/abilities/small_cold_protection.cfg
@@ -35,7 +35,7 @@
         [/affect_adjacent]
     [/resistance]
     [resistance]
-        add=-10
+        sub=10
         max_value=90
         apply_to=cold
         affect_self=no

--- a/data/ME_data/weapon_specials/highground.cfg
+++ b/data/ME_data/weapon_specials/highground.cfg
@@ -69,7 +69,7 @@
     [/damage]
     [damage]
         apply_to=self
-        add=-1
+        sub=1
         [filter_self]
             [filter_location]
                 [not]
@@ -88,7 +88,7 @@
     [/damage]
     [damage]
         apply_to=self
-        add=-1
+        sub=1
         [filter_self]
             [filter_location]
                 terrain={HIGH_TERRAINS}
@@ -102,7 +102,7 @@
     [/damage]
     [damage]
         apply_to=self
-        add=-2
+        sub=2
         [filter_self]
             [filter_location]
                 [not]

--- a/data/RE_data/condition_blur.cfg
+++ b/data/RE_data/condition_blur.cfg
@@ -13,7 +13,7 @@
         female_name= _ "blurred"
         description= _ "This unit currently has a blurred vision and trouble to hit. This status is healed at the end of this units turn."
         #add applies to magic as well
-        add=-15
+        sub=15
         cumulative=no
     [/chance_to_hit]
 #enddef

--- a/data/general_data/weapon_specials/specials.cfg
+++ b/data/general_data/weapon_specials/specials.cfg
@@ -23,21 +23,21 @@
         id=AE_special_counter
         name= _ "special counter"
         description= _ "This attack reduces magical chance to hit of opponents by 30% (down to 40%). It also reduces enchanted chance to hit of opponents by 20% (down to 40%). It also reduces precision chance to hit of opponents by 30% (down to 50%)."
-        add=-30
+        sub=30
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
-                special_id=magical,AE_mag_magical_defensive,AE_mag_magical_offensive,AE_mag_precision,AE_mag_precision_cumulative,AE_mag_precision_offensive,AE_agl_steelhive_precision
+                special_id_active=magical,AE_mag_magical_defensive,AE_mag_magical_offensive,AE_mag_precision,AE_mag_precision_cumulative,AE_mag_precision_offensive,AE_agl_steelhive_precision
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]
     [chance_to_hit]
         id=AE_special_counter2
-        add=-20
+        sub=20
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
-                special_id=AE_mag_enchanted
+                special_id_active=AE_mag_enchanted
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]

--- a/data/general_data/weapon_specials/specials.cfg
+++ b/data/general_data/weapon_specials/specials.cfg
@@ -27,7 +27,11 @@
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
-                special_id_active=magical,AE_mag_magical_defensive,AE_mag_magical_offensive,AE_mag_precision,AE_mag_precision_cumulative,AE_mag_precision_offensive,AE_agl_steelhive_precision
+                [filter_special]
+                    active=yes
+                    tag_name=chance_to_hit
+                    value=70-100
+                [/filter_special]
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]
@@ -37,7 +41,11 @@
         apply_to=opponent
         [filter_opponent]
             [filter_weapon]
-                special_id_active=AE_mag_enchanted
+                [filter_special]
+                    active=yes
+                    tag_name=chance_to_hit
+                    value=60
+                [/filter_special]
             [/filter_weapon]
         [/filter_opponent]
     [/chance_to_hit]

--- a/units/EE_units/monsters/Cuttlefish.cfg
+++ b/units/EE_units/monsters/Cuttlefish.cfg
@@ -50,7 +50,7 @@
                 id=AE_ext_ink
                 name=_"ink"
                 description= _ "Ink reduces opponents chance to hit by 15%"
-                add=-15
+                sub=15
                 apply_to=opponent
             [/chance_to_hit]
         [/specials]

--- a/units/EE_units/monsters/Young_Cuttlefish.cfg
+++ b/units/EE_units/monsters/Young_Cuttlefish.cfg
@@ -46,7 +46,7 @@
                 id=AE_ext_ink
                 name=_"ink"
                 description= _ "Ink reduces opponents chance to hit by 15%"
-                add=-15
+                sub=15
                 apply_to=opponent
             [/chance_to_hit]
         [/specials]

--- a/units/EoMa_units/Sky_Kingdom/Mirrorshield.cfg
+++ b/units/EoMa_units/Sky_Kingdom/Mirrorshield.cfg
@@ -181,7 +181,7 @@ The warrior's bravery and quick thinking earned him a reprieve from the Master C
     [/attack_anim]
 
 #define DEFLECT_MAGIC_FILTER
-    special_id=magical,AE_mag_enchanted,AE_mag_magical_offensive,AE_mag_magical_defensive
+    special_id_active=magical,AE_mag_enchanted,AE_mag_magical_offensive,AE_mag_magical_defensive
     type=fire,cold,arcane
     [not]
         type=secret


### PR DESCRIPTION
the issue with add= negative, are if two special with same id but two add of diffrent value are active,the special with the geatest value will be choosen, if by exemple we have add=-10 and add=-20, it add=-10 who will be used.

for prevent  this potential issue, use sub= instead, where sub=20will be used instead of sub=10.