### PR TITLE
EE - Chaos / fix Ageless Heroes faction id

### DIFF
--- a/factions/heroes/heroes-EE.cfg
+++ b/factions/heroes/heroes-EE.cfg
@@ -5,7 +5,7 @@
 ## | Chaos - Heroes
 
 [multiplayer_side]
-    id=AE_ext_chaos_Heroes
+    id=AE_side_ext_chaos
     name= "EE - " + _ "Chaos"
     image="units/chaos/blood-knight.png"
     type=AE_ext_chaos_Soulhunter


### PR DESCRIPTION
I think without the fix, `Random (EE)` in Ageless Heroes cannot roll into Chaos.

Well, probably nobody used the combination, but still.