### PR TITLE
Eoc Summoners / Master of Water uses watery resurgence

### DIFF
--- a/units/EoC_units/summoners/Master_of_Water.cfg
+++ b/units/EoC_units/summoners/Master_of_Water.cfg
@@ -31,7 +31,7 @@
         image="portraits/humans/mage-silver.webp"
     [/portrait]
     [abilities]
-        {ABILITY_FIERY_RESURGENCE}
+        {ABILITY_WATERY_RESURGENCE}
     [/abilities]
     [defense]
         shallow_water=60


### PR DESCRIPTION
Presumably the Master of Water should use the same watery version as the Summoner of Water?